### PR TITLE
Update lein Riemann plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+/target
+/lib
+/classes
+/checkouts
+pom.xml
+pom.xml.asc
+*.jar
+*.class
+.lein-deps-sum
+.lein-failures
+.lein-plugins
+.lein-repl-history
+.nrepl-port
+/out/
+/.repl/

--- a/src/leiningen/new/riemann/core.clj
+++ b/src/leiningen/new/riemann/core.clj
@@ -1,4 +1,4 @@
 (ns {{name}}.core
-	(:require [riemann.common :refer :all]
-		        [riemann.config :refer :all]
-		        [riemann.streams :refer :all]))
+    (:require [riemann.common :refer :all]
+              [riemann.config :refer :all]
+              [riemann.streams :refer :all]))

--- a/src/leiningen/new/riemann/core_test.clj
+++ b/src/leiningen/new/riemann/core_test.clj
@@ -1,2 +1,1 @@
-(ns {{name}}.core-test
-)
+(ns {{name}}.core-test)

--- a/src/leiningen/new/riemann/meta.edn
+++ b/src/leiningen/new/riemann/meta.edn
@@ -1,4 +1,4 @@
 {:plugin "{{name}}"
  :title  "A Riemann plugin."
  :git-repo "https://github.com/youruser/{{name}}"
- :require {{name}}.plugin}
+ :require {{name}}.core}

--- a/src/leiningen/new/riemann/project.clj
+++ b/src/leiningen/new/riemann/project.clj
@@ -1,12 +1,13 @@
-(defproject {{name}} ""
+(defproject {{name}} "0.1.0-SNAPSHOT"
 
   :description "FIXME: write description"
   :url "http://example.com/FIXME"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
 
-  :dependencies [[org.clojure/clojure "1.8.0"]]
+  :dependencies []
 
-  :profiles {:dev {:dependencies [[riemann "0.2.11"]]}}
+  :profiles {:dev {:dependencies [[riemann "0.3.0"]
+                                  [org.clojure/clojure "1.9.0"]]}}
 
   :resource-paths ["resources" "target/resources"])


### PR DESCRIPTION
- Move Clojure in :dev dependencies.
- Use Clojure 1.9 and Riemann 0.3.0.
- Add a default version for the created plugin.
- Change the required namespace in meta.edn.